### PR TITLE
Add missing entries for DotDirType

### DIFF
--- a/src/main/kotlin/io/github/rchowell/dotlin/Dot.kt
+++ b/src/main/kotlin/io/github/rchowell/dotlin/Dot.kt
@@ -947,6 +947,8 @@ enum class DotArrowType {
 
 enum class DotDirType {
     FORWARD,
+    BACK,
+    BOTH,
     NONE;
 
     override fun toString(): String = super.toString().lowercase()


### PR DESCRIPTION
As per the [documentation](https://graphviz.org/docs/attr-types/dirType/)